### PR TITLE
Force publicip.sh to use v4 and add publicip6.sh

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wlanpi-common (1.0.7) unstable; urgency=medium
+
+  * Force publicip.sh to use IPv4 and add publicip6.sh for IPv6.
+
+ -- Josh Schmelzle <josh@joshschmelzle.com>  Sat, 11 Dec 2021 18:46:55 -0500
+
 wlanpi-common (1.0.6-3) unstable; urgency=medium
 
   * wifichannel enhancements

--- a/opt/wlanpi-common/networkinfo/publicip.sh
+++ b/opt/wlanpi-common/networkinfo/publicip.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
-# Shows public IP address and related details 
+# Shows public IPv4 address and related details 
 
 #Get all data in JSON format 
-DATAINJSON=$(timeout 3 curl -s 'ifconfig.co/json')
+DATAINJSON=$(timeout 3 curl -s --ipv4 'ifconfig.co/json')
 
 if [ ! "$DATAINJSON" ]; then
-    echo "No public IP address detected"
+    echo "No public IPv4 address detected"
     #Conciously exiting with 0 to prevent error message in Python code that calls this script 
     exit 0
 fi
@@ -25,7 +25,7 @@ if [ "$PUBLICIP" ]; then
     echo "$PUBLICIPHOSTNAME"
     echo "$PUBLICIPASN"
 else
-    echo "No public IP address detected"
+    echo "No public IPv4 address detected"
 fi
 
 exit 0

--- a/opt/wlanpi-common/networkinfo/publicip6.sh
+++ b/opt/wlanpi-common/networkinfo/publicip6.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Shows public IPv6 address and related details 
+
+#Get all data in JSON format 
+DATAINJSON=$(timeout 3 curl -s --ipv6 'ifconfig.co/json')
+
+if [ ! "$DATAINJSON" ]; then
+    echo "No public IPv6 address detected"
+    #Conciously exiting with 0 to prevent error message in Python code that calls this script 
+    exit 0
+fi
+
+#Parse them
+PUBLICIP=$(echo "$DATAINJSON" | jq -r '.ip')
+PUBLICIPCOUNTRY=$(echo "$DATAINJSON" | jq -r '.country')
+PUBLICIPASNORG=$(echo "$DATAINJSON" | jq -r '.asn_org')
+PUBLICIPASN=$(echo "$DATAINJSON" | jq -r '.asn')
+
+#Display data
+if [ "$PUBLICIP" ]; then
+    echo "$PUBLICIP"
+    echo "$PUBLICIPCOUNTRY"
+    echo "$PUBLICIPASNORG"
+    echo "$PUBLICIPASN"
+else
+    echo "No public IPv6 address detected"
+fi
+
+exit 0
+


### PR DESCRIPTION
When the SBC is found on a dualstack environment with v4/v6 reachability, curl by default will use v6. This PR is to force `publicip.sh` to use v4, and adds a v6 version `publicip6.sh`.

IPv4:
```
./publicip.sh
25.25.25.25
United States
ABC-INTERNET
static-abc-25-25-25-25.litinternet.net
AS23456
```

IPv6 Example:

```
./publicip6.sh
2001:123:4567:11:dea6:33ff:ffff:22aa
United States
ABC
AS1234
```