### PR TITLE
On some networks ipconfig.co/json does not respond with a `hostname` attribute

### DIFF
--- a/opt/wlanpi-common/networkinfo/publicip.sh
+++ b/opt/wlanpi-common/networkinfo/publicip.sh
@@ -22,7 +22,11 @@ if [ "$PUBLICIP" ]; then
     echo "$PUBLICIP"
     echo "$PUBLICIPCOUNTRY"
     echo "$PUBLICIPASNORG"
-    echo "$PUBLICIPHOSTNAME"
+    if [ ! "$PUBLICIPHOSTNAME" ]; then
+        : 
+    else
+        echo "$PUBLICIPHOSTNAME"
+    fi
     echo "$PUBLICIPASN"
 else
     echo "No public IPv4 address detected"

--- a/opt/wlanpi-common/networkinfo/publicip.sh
+++ b/opt/wlanpi-common/networkinfo/publicip.sh
@@ -22,7 +22,7 @@ if [ "$PUBLICIP" ]; then
     echo "$PUBLICIP"
     echo "$PUBLICIPCOUNTRY"
     echo "$PUBLICIPASNORG"
-    if [ ! "$PUBLICIPHOSTNAME" ]; then
+    if [ "$PUBLICIPHOSTNAME" == "null" ]; then
         : 
     else
         echo "$PUBLICIPHOSTNAME"


### PR DESCRIPTION
IPv4 w/o hostname in ifconfig.co/json response:

```
XX.XXX.XXX.XX
United States
ATT-INTERNET4
null                          <------
ASXXXX
```

IPv4 with hostname in ifconfig.co/json response:

```
XX.XXX.XXX.XXX
United States
ACS-INTERNET
static-acs-XX-XXX-XXX-XXX.doominternet.net           <------
ASXXXXX
```