### PR TITLE
Create unique hostname for each WLAN Pi

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-wlanpi-common (1.0.17-5) unstable; urgency=medium
+wlanpi-common (1.0.17) unstable; urgency=medium
 
   * Renames WLAN Pi at startup to "wlanpi-<the last 3 characters of eth0 MAC address>"
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wlanpi-common (1.0.17) unstable; urgency=medium
+
+  * Renames WLAN Pi at startup to "wlanpi-<the last 3 characters of eth0 MAC address>"
+
+ -- Jiri Brejcha <jirka@jiribrejcha.net>  Fri, 21 Jan 2022 23:01:00 +0000
+
 wlanpi-common (1.0.16) unstable; urgency=medium
 
   * Adds MOTD tips after you SSH to the WLAN Pi

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-wlanpi-common (1.0.17) unstable; urgency=medium
+wlanpi-common (1.0.17-2) unstable; urgency=medium
 
   * Renames WLAN Pi at startup to "wlanpi-<the last 3 characters of eth0 MAC address>"
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-wlanpi-common (1.0.17-2) unstable; urgency=medium
+wlanpi-common (1.0.17-5) unstable; urgency=medium
 
   * Renames WLAN Pi at startup to "wlanpi-<the last 3 characters of eth0 MAC address>"
 

--- a/debian/control
+++ b/debian/control
@@ -9,6 +9,6 @@ Homepage: https://github.com/WLAN-Pi/wlanpi-common
 Package: wlanpi-common
 Architecture: any
 Multi-Arch: foreign
-Depends: ${misc:Depends}, ${shlibs:Depends}
+Depends: ${misc:Depends}, ${shlibs:Depends}, tcpdump, dig, arping, jq
 Description: Common WLAN Pi scripts and files
  Common WLAN Pi scripts and files.

--- a/debian/control
+++ b/debian/control
@@ -9,6 +9,6 @@ Homepage: https://github.com/WLAN-Pi/wlanpi-common
 Package: wlanpi-common
 Architecture: any
 Multi-Arch: foreign
-Depends: ${misc:Depends}, ${shlibs:Depends}, tcpdump, dig, arping, jq
+Depends: ${misc:Depends}, ${shlibs:Depends}, tcpdump, dnsutils, iputils-arping, jq
 Description: Common WLAN Pi scripts and files
  Common WLAN Pi scripts and files.

--- a/debian/rules
+++ b/debian/rules
@@ -13,6 +13,8 @@ override_dh_auto_install:
 
 override_dh_installinit:
 	dh_installinit --name=networkinfo
+	dh_installinit --name=wlanpi-rename-at-startup
 
 override_dh_systemd_enable:
 	dh_systemd_enable --name=networkinfo
+	dh_systemd_enable --name=wlanpi-rename-at-startup

--- a/debian/wlanpi-common.wlanpi-rename-at-startup.service
+++ b/debian/wlanpi-common.wlanpi-rename-at-startup.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Renames the WLAN Pi at startup to wlanpi-<the last 3 characters of eth0 MAC address>
+
+[Service]
+ExecStart=/opt/wlanpi-common/wlanpi-rename-at-startup.sh
+WorkingDirectory=/opt/wlanpi-common/
+
+[Install]
+WantedBy=multi-user.target

--- a/opt/wlanpi-common/wlanpi-rename-at-startup.sh
+++ b/opt/wlanpi-common/wlanpi-rename-at-startup.sh
@@ -4,25 +4,28 @@
 
 # Author: Jiri Brejcha, jirka@jiribrejcha.net, @jiribrejcha
 
+SCRIPT_NAME=$(echo ${0##*/})
+
 # Check if the script is running as root
 if [[ $EUID -ne 0 ]]; then
    echo "This script must run as root. Add \"sudo\" please".
    exit 1
 fi
 
-SCRIPT_NAME=$(echo ${0##*/})
-
 # Get the last 3 chars of eth0 MAC address
 LAST_3_CHARS_MAC=$(sed s/://g /sys/class/net/eth0/address | grep -o '...$')
 
 # Check if we got 3 chars
-if [ ${#LAST_3_CHARS_MAC} -eq 3 ]; then
-    ./wlanpi-hostname.sh set "wlanpi-$LAST_3_CHARS_MAC"
-    if [ "$?" != '0' ]; then
-        logger "($SCRIPT_NAME) Hostname change at startup failed!"
-        exit 1
-    fi
-else
+if [ ${#LAST_3_CHARS_MAC} -ne 3 ]; then
     logger "($SCRIPT_NAME) Failed to parse eth0 MAC address, skipping hostname change!"
     exit 1
+fi
+
+# If hostname matches wlanpi or wlanpi-<3-chars>, change it
+if [ "$HOSTNAME" == "wlanpi" ] || echo "$HOSTNAME" | grep -q "^wlanpi-...$" ; then
+    wlanpi-hostname set "wlanpi-$LAST_3_CHARS_MAC"
+    if [ "$?" != '0' ]; then
+        logger "($SCRIPT_NAME) Hostname change failed!"
+        exit 1
+    fi
 fi

--- a/opt/wlanpi-common/wlanpi-rename-at-startup.sh
+++ b/opt/wlanpi-common/wlanpi-rename-at-startup.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Creates a unique name for  WLAN Pi at startup in this format "wlanpi-<the last 3 characters of eth0 MAC address>" 
+
+# Author: Jiri Brejcha, jirka@jiribrejcha.net, @jiribrejcha
+
+# Check if the script is running as root
+if [[ $EUID -ne 0 ]]; then
+   echo "This script must run as root. Add \"sudo\" please".
+   exit 1
+fi
+
+SCRIPT_NAME=$(echo ${0##*/})
+
+# Get the last 3 chars of eth0 MAC address
+LAST_3_CHARS_MAC=$(sed s/://g /sys/class/net/eth0/address | grep -o '...$')
+
+# Check if we got 3 chars
+if [ ${#LAST_3_CHARS_MAC} -eq 3 ]; then
+    ./wlanpi-hostname.sh set "wlanpi-$LAST_3_CHARS_MAC"
+    if [ "$?" != '0' ]; then
+        logger "($SCRIPT_NAME) Hostname change at startup failed!"
+        exit 1
+    fi
+else
+    logger "($SCRIPT_NAME) Failed to parse eth0 MAC address, skipping hostname change!"
+fi

--- a/opt/wlanpi-common/wlanpi-rename-at-startup.sh
+++ b/opt/wlanpi-common/wlanpi-rename-at-startup.sh
@@ -24,4 +24,5 @@ if [ ${#LAST_3_CHARS_MAC} -eq 3 ]; then
     fi
 else
     logger "($SCRIPT_NAME) Failed to parse eth0 MAC address, skipping hostname change!"
+    exit 1
 fi


### PR DESCRIPTION
This script makes each WLAN Pi's hostname unique by changing "wlanpi" or "wlanpi-xxx" hostname to wlanpi-<last 3 chars of eth0 MAC address>.