### PR TITLE
wlanpi-hostname: restarts avahi-daemon for new hostname to take effect

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wlanpi-common (1.0.25-2.1) unstable; urgency=medium
+
+  * Restarts avahi-daemon when setting a new hostname
+
+ -- Adrian Granados <adrian@intuitibits.com>  Mon, 31 Jan 2022 23:20:00 -0600
+
 wlanpi-common (1.0.25-2) unstable; urgency=medium
 
   * Add tips, remove tips with external links


### PR DESCRIPTION
By restarting avahi-daemon after setting the hostname, the Pi can be immediately reached by using the new hostname. 

Because renaming the hostname on boot relies on wlanpi-hostname, this change also fixes renaming hostname after first boot (wlanpi -> wlanpi-xxx) and when switching the SD card to a different Pi (wlanpi-xxx -> wlanpi-yyy).

I also changed wlanpi-hostname so that if the current hostname is equal to the new hostname, then nothing is done (the idea here is not to restart avahi unnecessarily).