### PR TITLE
Add WLAN Pi mDNS service announcement to Avahi

### DIFF
--- a/debian/wlanpi-common.install
+++ b/debian/wlanpi-common.install
@@ -3,4 +3,6 @@ usr/bin/wlanpi-stats usr/bin/
 etc/profile.d/wlanpi-stats.sh etc/profile.d/
 etc/sudoers.d/spectools etc/sudoers.d/
 etc/systemd/system/isc-dhcp-server.service.d/* etc/systemd/system/isc-dhcp-server.service.d/
+etc/systemd/system/avahi-daemon.service.d/* etc/systemd/system/avahi-daemon.service.d/
+etc/avahi/services/wlanpi_announce.service etc/avahi/services/
 etc/apt/apt.conf.d/80wlanpi etc/apt/apt.conf.d/

--- a/debian/wlanpi-common.links
+++ b/debian/wlanpi-common.links
@@ -22,3 +22,4 @@ opt/wlanpi-common/wlanpi-charger-boost.sh usr/bin/wlanpi-charger-boost
 opt/wlanpi-common/wlanpi-bluetooth.sh usr/bin/wlanpi-bluetooth
 opt/wlanpi-common/wlanpi-model.sh usr/bin/wlanpi-model
 opt/wlanpi-common/wpdev.sh usr/bin/wpdev
+opt/wlanpi-common/wlanpi-avahi-service-update.sh usr/bin/wlanpi-avahi-service-update

--- a/etc/avahi/services/wlanpi_announce.service
+++ b/etc/avahi/services/wlanpi_announce.service
@@ -1,0 +1,11 @@
+<?xml version="1.0" standalone='no'?><!--*-nxml-*-->
+<!DOCTYPE service-group SYSTEM "avahi-service.dtd">
+<service-group>
+<name replace-wildcards="yes">WLAN Pi (%h)</name>
+<service>
+<type>_http._tcp</type>
+<port>31415</port>
+<txt-record>model=WLAN Pi</txt-record>
+<txt-record>ver=0</txt-record>
+</service>
+</service-group>

--- a/etc/systemd/system/avahi-daemon.service.d/override.conf
+++ b/etc/systemd/system/avahi-daemon.service.d/override.conf
@@ -1,0 +1,2 @@
+[Service]
+ExecStartPost=-/usr/bin/wlanpi-avahi-service-update

--- a/opt/wlanpi-common/wlanpi-avahi-service-update.sh
+++ b/opt/wlanpi-common/wlanpi-avahi-service-update.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+WLANPI_MODEL_CMD="/usr/bin/wlanpi-model"
+WLANPI_RELEASE_FILE="/etc/wlanpi-release"
+SERVICE_FILE="/etc/avahi/services/wlanpi_announce.service"
+
+for req in "$WLANPI_MODEL_CMD" "$WLANPI_RELEASE_FILE" "$SERVICE_FILE"; do
+    if [ ! -f "$req" ]; then
+        echo "Error: Required file $req not found!" >&2
+        exit 1
+    fi
+done
+
+if ! MODEL=$("$WLANPI_MODEL_CMD" | awk -F': +' '/^Model/ { print $2 }'); then
+    echo "Error: Failed to get model information" >&2
+    exit 1
+fi
+
+if [ -z "$MODEL" ]; then
+    echo "Error: Empty model information" >&2
+    exit 1
+fi
+
+if ! VERSION=$(cat "$WLANPI_RELEASE_FILE"); then
+    echo "Error: Failed to read version file" >&2
+    exit 1
+fi
+
+if [ -z "$VERSION" ]; then
+    echo "Error: Empty version information" >&2
+    exit 1
+fi
+
+if ! sed -i -E \
+    -e "s|<txt-record>model=.*</txt-record>|<txt-record>model=$MODEL</txt-record>|" \
+    -e "s|<txt-record>ver=.*</txt-record>|<txt-record>ver=$VERSION</txt-record>|" \
+    "$SERVICE_FILE"; then
+    echo "Error: Failed to update service file" >&2
+    exit 1
+fi
+
+if ! grep -q "<txt-record>model=$MODEL</txt-record>" "$SERVICE_FILE" || \
+   ! grep -q "<txt-record>ver=$VERSION</txt-record>" "$SERVICE_FILE"; then
+    echo "Error: Failed to verify changes" >&2
+    exit 1
+fi


### PR DESCRIPTION
Include Avahi service
Amend the systemd service to dynamically update the service descriptor

## Type of change 

*Pick at least one.*

* [ ] Bug fix (non-breaking change that fixes something)
* [ ] Documentation update (readme, changelog, man page, etc.)
* [x] New feature (non-breaking change adding functionality)
* [ ] Breaking change (fix or feature changing existing functionality)
* [ ] Code quality improvement (refactor, performance improvements)
* [ ] Other (please specify):

## Breaking change

*Does this Pull Request introduce a breaking change?* 

- What functionality breaks?
- Why does it break?
- How should it be migrated?  
- Are there any backward-compatible alternatives?

## Proposed change

Adding mDNS service announcement on Avahi.
Service announcement is dynamically updated to include the WLANPi model and OS version



## Testing

Tested by running on a local device

- [ ] Did you add new automated tests? If yes, explain which edge cases are covered.
- [ ] Does this change affect any existing tests? If so, how did you adjust them?
- [ ] Please provide test run results or screenshots if applicable.

## Checklist

* [x] I have read the [contribution guidelines and policies](https://github.com/WLAN-Pi/.github/blob/main/docs/contributing.md)
* [x] I have targeted this PR against the correct git branch
* [x] I ran the test suite and verified it succeeded
* [x] I linked an approved GitHub issue to this PR (in the next section). No PR without a related GH issue. Conversations about your PR efforts in other channels such as electronic mail, social media, morse code, and WLAN Pi Slack **do not count**.
* [ ] I have updated the changelog (if applicable)
* [ ] I have added or updated the documentation (if applicable)

## Related Issues/PRs

*Pick at least one.*

- This PR fixes/closes issue #
- This PR is related to issue #
- This PR depends on/blocks PR #