### PR TITLE
fix: unit mismatch in firmware backup space check

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wlanpi-common (1.1.36-1) unstable; urgency=medium
+
+  * fix: unit mismatch in firmware backup space check
+  
+  -- Josh Schmelzle <josh@joshschmelzle.com>  Fri, 26 Sep 2025 00:00:00 -0400
+
 wlanpi-common (1.1.35-1) unstable; urgency=medium
 
   * Add support for eth1

--- a/opt/wlanpi-common/wlanpi-iwlwifi-ucode-92.sh
+++ b/opt/wlanpi-common/wlanpi-iwlwifi-ucode-92.sh
@@ -24,6 +24,7 @@ check_space() {
     if [ -f "$file" ]; then
         required_space=$(stat -c%s "$file")
         available_space=$(df --output=avail "$FIRMWARE_DIR" | tail -n1)
+        available_space=$((available_space * 1024))
         [ "$available_space" -gt "$required_space" ] || error_exit "Insufficient space for backup ..."
     fi
 }


### PR DESCRIPTION
## Type of change 

<!--
Feel free to remove sections and items that don't pertain to the context of your PR.
For example, if you're updating docs, you don't need the testing section.
Note that you do not need to delete these HTML comments as they are not visible after the PR is submitted.
-->

<!-- *Pick at least one.* -->

* [X] Bug fix (non-breaking change that fixes something)
* [ ] Documentation update (readme, changelog, man page, etc.)
* [ ] New feature (non-breaking change adding functionality)
* [ ] Breaking change (fix or feature changing existing functionality)
* [ ] Code quality improvement (refactor, performance improvements)
* [ ] Other (please specify):

## Breaking change

<!-- *Does this Pull Request introduce a breaking change?* -->

- What functionality breaks?
- Why does it break?
- How should it be migrated?  
- Are there any backward-compatible alternatives?

## Proposed change

<!-- *Please describe the purpose of this change, the problem it solves, and why the change is necessary. Including code snippets or links to related documentation when applicable will assist approval.* -->

The check_space() function was comparing bytes (from stat) against 
kilobytes (from df), causing false "insufficient space" errors.

## Testing

<!-- *Please explain how you tested this change manually, and if applicable, what new tests you added.* -->

- [ ] Did you add new automated tests? If yes, explain which edge cases are covered.
- [ ] Does this change affect any existing tests? If so, how did you adjust them?
- [ ] Please provide test run results or screenshots if applicable.

Before change:

```
wlanpi@wlanpi-fba:~ $ wlanpi-iwlwifi-ucode-92 disable
[2025-09-19 11:17:41] Creating original backup...
[2025-09-19 11:17:41] ERROR: Insufficient space for backup ...
```

After change:

```
wlanpi@wlanpi-fba:~ $ wlanpi-iwlwifi-ucode-92 disable
[2025-09-19 11:22:52] Creating original backup...
[2025-09-19 11:22:52] Original backup created successfully ...
[2025-09-19 11:22:52] Moving firmware file to disabled state ...
[2025-09-19 11:22:52] Firmware disabled ...
[2025-09-19 11:22:52] Resetting wireless modules ...
[2025-09-19 11:22:55] Wireless modules reset complete ...
```

## Checklist

<!-- No PR without a related GH issue! Conversations about your PR efforts in other channels such as electronic mail, social media, morse code, homing pigeon, or slack are great starting points, but **do not count** for this requirement. --> 

* [X] I have read the [contribution guidelines and policies](https://github.com/WLAN-Pi/.github/blob/main/docs/contributing.md)
* [X] I have targeted this PR against the correct git branch (this can vary depending on the default branch of the repo)
* [ ] I ran the test suite and verified it succeeded
* [X] I linked a GitHub issue to this PR (in the next section). 
* [ ] I have updated the changelog (if applicable)
* [ ] I have added or updated the documentation (if applicable)

## Related Issues/PRs

<!-- *Pick at least one. Delete the other lines.* -->

- This PR fixes/closes issue #51 
- This PR is related to issue #
- This PR depends on/blocks PR #