### PR TITLE
Remove wconsole mode from wlanpi-common

### DIFF
--- a/opt/wlanpi-common/motd-tips.txt
+++ b/opt/wlanpi-common/motd-tips.txt
@@ -13,5 +13,5 @@ Let us know if you have any ideas or suggestions about how to improve WLAN Pi ht
 Have you tried "wifichannel -6"? It shows all 6 GHz channels, and highlights all Preferred Scanning Channels (PSC).
 SSH to your WLAN Pi, or access the web UI, via Bluetooth from your tablet or phone: Menu > Bluetooth > Pair Device
 Start Profiler on a custom channel by "sudo profiler -c 1" or "sudo profiler -c 40".
-Connect your phone or tablet to WLAN Pi by scanning a QR code. Switch to Hotspot, Wi-Fi Console, or Server mode, and press the center button to display the QR code.
+Connect your phone or tablet to WLAN Pi by scanning a QR code. Switch to Hotspot or Server mode, and press the center button to display the QR code.
 Use "wlanpi-model" to see your WLAN Pi model and installed Wi-Fi adapter.

--- a/opt/wlanpi-common/wlanpi-mode.sh
+++ b/opt/wlanpi-common/wlanpi-mode.sh
@@ -5,7 +5,6 @@
 #
 # This script is uses the following scripts to change modes
 #  - /opt/wlanpi-hotspot/hotspot_switcher
-#  - /opt/wlanpi-hotspot/wconsole_switcher
 #  - /opt/wlanpi-hotspot/server_switcher
 #
 # To get the current mode, the followign file is read:
@@ -14,7 +13,6 @@
 # States available:
 #  - classic
 #  - hotspot
-#  - wconsole
 #  - server
 #
 # Return values:
@@ -35,7 +33,6 @@ MODE=""
 SCRIPT_NAME=$(echo ${0##*/})
 
 HOTSPOT_SWITCHER="/opt/wlanpi-hotspot/hotspot_switcher"
-WCONSOLE_SWITCHER="/opt/wlanpi-wconsole/wconsole_switcher"
 SERVER_SWITCHER="/opt/wlanpi-server/server_switcher"
 CONFIRM_REQ=$3
 
@@ -127,7 +124,7 @@ set_mode() {
     NEW_MODE=$1
 
     # check new mode is valid
-    if [[ ! $NEW_MODE =~ (classic|hotspot|wconsole|server) ]]; then
+    if [[ ! $NEW_MODE =~ (classic|hotspot|server) ]]; then
         echo "* Invalid mode requested : $NEW_MODE"
         exit 1
     fi
@@ -153,11 +150,6 @@ set_mode() {
             check_yn
             `$HOTSPOT_SWITCHER on`
             ;;
-    wconsole)
-            echo "* Switching from classic to wconsole mode"
-            check_yn
-            `$WCONSOLE_SWITCHER on`
-            ;;
     server)
             echo "* Switching from classic to server mode"
             check_yn
@@ -169,11 +161,6 @@ set_mode() {
                     echo "* Switching from hotspot to classic mode";
                     check_yn;
                     `$HOTSPOT_SWITCHER off`
-                    ;;
-            wconsole)
-                    echo "* Switching from wconsole to classic mode";
-                    check_yn;
-                    `$WCONSOLE_SWITCHER off`
                     ;;
             server)
                     echo "* Switching from server to classic mode";
@@ -197,8 +184,8 @@ usage () {
         echo "Usage: wlanpi-mode.sh { get | set | help }"
         echo ""
         echo "  wlanpi-mode.sh get: show current mode"
-        echo "  wlanpi-mode.sh set [ classic | hotspot | wconsole | server ]"
-        echo "  wlanpi-mode.sh set [ classic | hotspot | wconsole | server ] [ -q ] (quiet switch)"
+        echo "  wlanpi-mode.sh set [ classic | hotspot | server ]"
+        echo "  wlanpi-mode.sh set [ classic | hotspot | server ] [ -q ] (quiet switch)"
         echo "  wlanpi-mode.sh : show usage info"
         echo ""
         exit 0


### PR DESCRIPTION
## Summary

<!-- Briefly describe the change and why it's needed -->

## Type of change

- [x] Enhancement

## Proposed change

Remove dedicated mode of wconsole and rely on hotspot mode with additional functionality.

## Testing

<!-- How was this tested? -->
- [X] Tested manually on a WLAN Pi
-  Made change to wlanpi-mode.sh locally, copied to wlanpi and ran.


## AI assistance

- [X] I used AI/LLM assistance
- If yes: Tool(s) used: Gemini used to validate that changes were valid code before starting manual testing.

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/WLAN-Pi/.github/blob/main/docs/contributing.md)
- [ ] I targeted the correct branch (in general: `dev` for features/fixes, `main` for hotfixes)
- [X] This PR fixes/closes issue #_ (or relates to issue #_)
- #55 
## Breaking changes

<!-- Only fill out if you checked "Breaking change" above -->

- **What breaks:** 
- **Migration needed:** 
