### PR TITLE
Remove bullseye from GH actions on main branch

### DIFF
--- a/.github/workflows/build-and-archive-debian-package.yml
+++ b/.github/workflows/build-and-archive-debian-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: [bullseye,bookworm,trixie]
+        distro: [bookworm,trixie]
         arch: [arm64]
     
     steps:

--- a/.github/workflows/deploy-to-packagecloud.yml
+++ b/.github/workflows/deploy-to-packagecloud.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: [bullseye,bookworm,trixie]
+        distro: [bookworm,trixie]
         arch: [arm64]
 
     environment: PACKAGECLOUD


### PR DESCRIPTION
## Summary

<!-- Briefly describe the change and why it's needed -->

Stop producing bullseye images by default. Use debian/bullseye branch for any bullseye maintenance moving forward.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [X] Breaking change
- [ ] Documentation
- [ ] Other: 

## Proposed change

<!-- What problem does this solve? What was changed? -->

Removes bullseye from matrix

## Testing

<!-- How was this tested? -->
- [ ] Added/updated automated tests
- [ ] Tested manually on a WLAN Pi
- [ ] Tested in another environment

## AI assistance

- [ ] I used AI/LLM assistance
- If yes: Tool(s) used: 

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/WLAN-Pi/.github/blob/main/docs/contributing.md)
- [ ] I targeted the correct branch (in general: `dev` for features/fixes, `main` for hotfixes)
- [ ] This PR fixes/closes issue #_ (or relates to issue #_)

## Breaking changes

<!-- Only fill out if you checked "Breaking change" above -->

- **What breaks:** 
- **Migration needed:** 
