### PR TITLE
Handle config file location variance for config location

### DIFF
--- a/opt/wlanpi-common/wlanpi-model.sh
+++ b/opt/wlanpi-common/wlanpi-model.sh
@@ -52,6 +52,15 @@ debugger() {
     fi
 }
 
+if [ -d "/boot/firmware" ]; then
+    CONFIG_FILE="/boot/firmware/config.txt"
+elif [ -d "/boot" ]; then
+    CONFIG_FILE="/boot/config.txt"
+else
+    echo "ERROR: Boot not found"
+    exit 1
+fi
+
 # Is it Raspberry Pi 3? It isn't officially supported but let's pretend it is R4.
 if grep -q "Raspberry Pi 3 Model B Rev 1.2" /proc/cpuinfo; then
     if [ "$BRIEF_OUTPUT" -ne 0 ];then
@@ -117,7 +126,7 @@ elif grep -q "Raspberry Pi Compute Module 4" /proc/cpuinfo; then
             else
                 echo "Model:                WLAN Pi M4+"
                 echo "Main board:           Mcuzone M4+"
-                if grep -q -E "^\s*otg_mode=1" /boot/config.txt && [ $(lsusb | wc -l) -gt 1 ]; then
+                if grep -q -E "^\s*otg_mode=1" $CONFIG_FILE && [ $(lsusb | wc -l) -gt 1 ]; then
                     echo "USB mode:             Host - Bluetooth and USB-A ports enabled"
                 else
                     echo "USB mode:             OTG - Bluetooth and USB-A ports disabled"


### PR DESCRIPTION
## Summary

<!-- Briefly describe the change and why it's needed -->

Sometimes config.txt is actually in /boot/firmware instead of /boot.

## Type of change

- [X] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: 

## Proposed change

<!-- What problem does this solve? What was changed? -->

Adds config file location detection for /boot/firmware/config.txt or /boot/config.txt.

## Testing

<!-- How was this tested? -->
- [ ] Added/updated automated tests
- [X] Tested manually on a WLAN Pi
- [ ] Tested in another environment

## AI assistance

- [ ] I used AI/LLM assistance
- If yes: Tool(s) used: 

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/WLAN-Pi/.github/blob/main/docs/contributing.md)
- [X] I targeted the correct branch (in general: `dev` for features/fixes, `main` for hotfixes)
- [X] This PR closes #61 

## Breaking changes

<!-- Only fill out if you checked "Breaking change" above -->

- **What breaks:** 
- **Migration needed:** 
