### PR TITLE
Ensure REG domain is set to uppercase

### DIFF
--- a/opt/wlanpi-common/wlanpi-reg-domain.sh
+++ b/opt/wlanpi-common/wlanpi-reg-domain.sh
@@ -119,6 +119,9 @@ set_domain () {
        exit 1
     fi
 
+    # ensure domain is uppercase
+    DOMAIN="${DOMAIN^^}"
+
     # set the new reg domain in the config file
      sed -i "s/REGDOMAIN=.*/REGDOMAIN=$DOMAIN/" "$REG_DOMAIN_FILE"
 


### PR DESCRIPTION
## Summary

<!-- Briefly describe the change and why it's needed -->

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: 

## Proposed change

Ensures that reg domain is set to uppercase.

## Testing

<!-- How was this tested? -->
- [ ] Added/updated automated tests
- [ ] Tested manually on a WLAN Pi
- [ ] Tested in another environment
- [X] Didn't Test

## AI assistance

- [X] I used AI/LLM assistance
- If yes: Tool(s) used: Gemini, to validate that my bash syntax was correct and works.

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/WLAN-Pi/.github/blob/main/docs/contributing.md)
- [X] I targeted the correct branch (in general: `dev` for features/fixes, `main` for hotfixes)
- [X] This PR closes #57 

## Breaking changes

- **What breaks:** 
- **Migration needed:** 
