### PR TITLE
Add support for LPI/SP and references to band.

### DIFF
--- a/opt/wlanpi-common/tests/wifichannel-test01.sh
+++ b/opt/wlanpi-common/tests/wifichannel-test01.sh
@@ -173,6 +173,32 @@ run_tests () {
   check_output "Ch 36 still shows U-NII band" "36" "U-NII-1"
   check_output "Ch 132 still shows U-NII band" "132" "U-NII-2C"
 
+  # ---- U-NII band listing tests ----
+  check_all_lines "U-NII-1 listing shows U-NII-1" "-unii-1" "U-NII-1"
+  check_all_lines "U-NII-1 listing shows 5 GHz" "-unii-1" "Band: 5 GHz"
+  check_output "U-NII-1 listing includes ch 36" "-unii-1" "Channel:  36"
+  check_output "U-NII-1 listing includes ch 48" "-unii-1" "Channel:  48"
+  check_all_lines "U-NII-2A listing shows U-NII-2A" "-unii-2a" "U-NII-2A"
+  check_output "U-NII-2A listing includes ch 52" "-unii-2a" "Channel:  52"
+  check_all_lines "U-NII-2C listing shows U-NII-2C" "-unii-2c" "U-NII-2C"
+  check_output "U-NII-2C listing includes ch 100" "-unii-2c" "Channel:  100"
+  check_all_lines "U-NII-3 listing shows U-NII-3" "-unii-3" "U-NII-3"
+  check_output "U-NII-3 listing includes ch 149" "-unii-3" "Channel:  149"
+  check_all_lines "U-NII-4 listing shows U-NII-4" "-unii-4" "U-NII-4"
+  check_output "U-NII-4 listing includes ch 169" "-unii-4" "Channel:  169"
+  check_all_lines "U-NII-5 listing shows U-NII-5" "-unii-5" "U-NII-5"
+  check_all_lines "U-NII-5 listing shows 6 GHz" "-unii-5" "Band: 6 GHz"
+  check_output "U-NII-5 listing includes ch 1" "-unii-5" "Channel:   1"
+  check_output "U-NII-5 listing includes ch 93" "-unii-5" "Channel:  93"
+  check_all_lines "U-NII-6 listing shows U-NII-6" "-unii-6" "U-NII-6"
+  check_output "U-NII-6 listing includes ch 97" "-unii-6" "Channel:  97"
+  check_all_lines "U-NII-7 listing shows U-NII-7" "-unii-7" "U-NII-7"
+  check_output "U-NII-7 listing includes ch 117" "-unii-7" "Channel: 117"
+  check_all_lines "U-NII-8 listing shows U-NII-8" "-unii-8" "U-NII-8"
+  check_output "U-NII-8 listing includes ch 185" "-unii-8" "Channel: 185"
+  check_all_lines "U-NII band listing has Widths" "-unii-1" "Widths:"
+  check_all_lines "U-NII-5 listing has Power class" "-unii-5" "Power:"
+
   # ---- Error handling preserved ----
   info "Invalid input still shows error"
   output=$($SCRIPT_NAME "abc" 2>&1)

--- a/opt/wlanpi-common/wifichannel.sh
+++ b/opt/wlanpi-common/wifichannel.sh
@@ -103,6 +103,16 @@ usage(){
     echo "  -2.4, -2       List all 2.4 GHz channels"
     echo "  -5             List all 5 GHz channels"
     echo "  -6             List all 6 GHz channels"
+    echo "  -unii-1        List U-NII-1 channels (5 GHz)"
+    echo "  -unii-2        List U-NII-2A and U-NII-2C channels (5 GHz)"
+    echo "  -unii-2a       List U-NII-2A channels (5 GHz)"
+    echo "  -unii-2c       List U-NII-2C channels (5 GHz)"
+    echo "  -unii-3        List U-NII-3 channels (5 GHz)"
+    echo "  -unii-4        List U-NII-4 channels (5 GHz)"
+    echo "  -unii-5        List U-NII-5 channels (6 GHz)"
+    echo "  -unii-6        List U-NII-6 channels (6 GHz)"
+    echo "  -unii-7        List U-NII-7 channels (6 GHz)"
+    echo "  -unii-8        List U-NII-8 channels (6 GHz)"
     echo
     exit 0
 }
@@ -175,6 +185,72 @@ show_all_5(){
             echo "Band: $BAND GHz   Channel: $INPUT   Center freq: $((($INPUT * 5) + 5000)) MHz   U-NII-3    Widths: $WIDTHS"
         elif [[ " ${UNII_4_CHANNELS[*]} " =~ " ${INPUT} " ]]; then
             echo "Band: $BAND GHz   Channel: $INPUT   Center freq: $((($INPUT * 5) + 5000)) MHz   U-NII-4    Widths: $WIDTHS"
+        fi
+    done
+    exit 0
+}
+
+# Returns the U-NII band for a given 5 GHz channel
+get_5ghz_unii_band(){
+    local channel=$1
+    if [[ " ${UNII_1_CHANNELS[*]} " =~ " ${channel} " ]]; then
+        echo "U-NII-1"
+    elif [[ " ${UNII_2A_CHANNELS[*]} " =~ " ${channel} " ]]; then
+        echo "U-NII-2A"
+    elif [[ " ${UNII_2C_CHANNELS[*]} " =~ " ${channel} " ]]; then
+        echo "U-NII-2C"
+    elif [[ " ${UNII_3_CHANNELS[*]} " =~ " ${channel} " ]]; then
+        echo "U-NII-3"
+    elif [[ " ${UNII_4_CHANNELS[*]} " =~ " ${channel} " ]]; then
+        echo "U-NII-4"
+    fi
+}
+
+# List channels for a specific 5 GHz U-NII band
+show_5ghz_unii(){
+    local unii_name=$1
+    shift
+    local channels=("$@")
+    BAND="5"
+    for INPUT in "${channels[@]}"; do
+        # Skip bonded channels (only show 20 MHz base channels)
+        if [[ ! " ${UNBONDED_5_CHANNELS[*]} " =~ " ${INPUT} " ]]; then
+            continue
+        fi
+        WIDTHS=$(get_channel_widths "5" "$INPUT")
+        local display_band=$(get_5ghz_unii_band "$INPUT")
+        echo "Band: $BAND GHz   Channel:  $INPUT   Center freq: $((($INPUT * 5) + 5000)) MHz   $display_band   Widths: $WIDTHS"
+    done
+    exit 0
+}
+
+# List channels for a specific 6 GHz U-NII band
+show_6ghz_unii(){
+    local unii_name=$1
+    local min_ch=$2
+    local max_ch=$3
+    BAND="6"
+    for INPUT in $(seq $min_ch $max_ch); do
+        if [ $(($INPUT%4)) -ne 1 ]; then
+            continue
+        fi
+        PAD=""
+        if [ ${#INPUT} -eq 1 ]; then
+            PAD="  "
+        elif [ ${#INPUT} -eq 2 ]; then
+            PAD=" "
+        fi
+        if [ $INPUT -le 93 ]; then
+            LOWER_UPPER="Lower 6 GHz"
+        else
+            LOWER_UPPER="Upper 6 GHz"
+        fi
+        POWER_CLASS=$(get_6ghz_power_class "$INPUT")
+        WIDTHS=$(get_channel_widths "6" "$INPUT")
+        if [ $(($INPUT%16)) -eq 5 ]; then
+            echo "Band: $BAND GHz   Channel:$PAD $INPUT   Center freq: $((($INPUT * 5) + 5950)) MHz   PSC: Yes   $LOWER_UPPER   $unii_name   Power: $POWER_CLASS   Widths: $WIDTHS"
+        else
+            echo "Band: $BAND GHz   Channel:$PAD $INPUT   Center freq: $((($INPUT * 5) + 5950)) MHz   PSC: No    $LOWER_UPPER   $unii_name   Power: $POWER_CLASS   Widths: $WIDTHS"
         fi
     done
     exit 0
@@ -357,6 +433,16 @@ case $INPUT in
     -2.4 | -2) show_all_2_4 ;;
     -5) show_all_5 ;;
     -6) show_all_6 ;;
+    -unii-1 | -unii1) show_5ghz_unii "U-NII-1" "${UNII_1_CHANNELS[@]}" ;;
+    -unii-2 | -unii2) show_5ghz_unii "U-NII-2" "${UNII_2A_CHANNELS[@]}" "${UNII_2C_CHANNELS[@]}" ;;
+    -unii-2a | -unii2a) show_5ghz_unii "U-NII-2A" "${UNII_2A_CHANNELS[@]}" ;;
+    -unii-2c | -unii2c) show_5ghz_unii "U-NII-2C" "${UNII_2C_CHANNELS[@]}" ;;
+    -unii-3 | -unii3) show_5ghz_unii "U-NII-3" "${UNII_3_CHANNELS[@]}" ;;
+    -unii-4 | -unii4) show_5ghz_unii "U-NII-4" "${UNII_4_CHANNELS[@]}" ;;
+    -unii-5 | -unii5) show_6ghz_unii "U-NII-5" 1 93 ;;
+    -unii-6 | -unii6) show_6ghz_unii "U-NII-6" 97 113 ;;
+    -unii-7 | -unii7) show_6ghz_unii "U-NII-7" 117 181 ;;
+    -unii-8 | -unii8) show_6ghz_unii "U-NII-8" 185 233 ;;
     ''|*[!0-9]*) invalid_input ;;
 esac
 


### PR DESCRIPTION
## Summary

Adds support for LPI and SPI to the output for 6GHz.
Adds support for listing channels by band.

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: 

## Proposed change

Contributes to my laziness.

## Testing

<!-- How was this tested? -->
- [X] Added/updated automated tests
- [ ] Tested manually on a WLAN Pi
- [X] Tested in another environment

## AI assistance

- [X] I used AI/LLM assistance
- If yes: Tool(s) used: Claude code.

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/WLAN-Pi/.github/blob/main/docs/contributing.md)
- [X] I targeted the correct branch (in general: `dev` for features/fixes, `main` for hotfixes)
- [X] This PR fixes/closes issue #_ (or relates to issue)
closes #35 

## Breaking changes


- **What breaks:** 
- **Migration needed:** 
