### PR TITLE
M4 model detection default

### DIFF
--- a/opt/wlanpi-common/wlanpi-model.sh
+++ b/opt/wlanpi-common/wlanpi-model.sh
@@ -148,7 +148,6 @@ elif grep -q "Raspberry Pi Compute Module 4" /proc/cpuinfo; then
         debugger "End script now. Platform is M4+ prototype with PCIe packet switch."
     # Assume M4
     else
-        debugger "HDMI module found loaded"
             # HDMI module is loaded (status 0)
         if [ "$BRIEF_OUTPUT" -ne 0 ]; then
             echo "M4"


### PR DESCRIPTION
## Summary

M4 was not being detected due to HDMI module changes in bookworm.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: 

## Proposed change

Moves from using HDMI to just assuming that anything not M4+ is an M4.
## Testing

<!-- How was this tested? -->
- [ ] Added/updated automated tests
- [X] Tested manually on a WLAN Pi
- [ ] Tested in another environment

## AI assistance

- [X] I used AI/LLM assistance
- If yes: Tool(s) used: Claude

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/WLAN-Pi/.github/blob/main/docs/contributing.md)
- [X] I targeted the correct branch (in general: `dev` for features/fixes, `main` for hotfixes)
- [X] This PR fixes/closes issue #_ (or relates to issue #37 
Closes #66 

## Breaking changes

Breaks unknown models.

- **What breaks:**
- **Migration needed:** 
