### PR TITLE
Add deviceID for QCA WCN785x

### DIFF
--- a/opt/wlanpi-common/wlanpi-config-at-startup.sh
+++ b/opt/wlanpi-common/wlanpi-config-at-startup.sh
@@ -173,8 +173,8 @@ if [[ "$BOARD" == "Mcuzone M4" ]]; then
         debugger "USB mode is already set to host mode, no action needed"
     fi
 
-    # Enable pcie-32bit-dma overlay for MediaTek M.2 Wi-Fi adapters to work
-    if lspci -nn | grep -q -E "14c3:0608|14c3:0616|14c3:7925"; then
+    # Enable pcie-32bit-dma overlay for MediaTek and QCA M.2 Wi-Fi adapters to work
+    if lspci -nn | grep -q -E "14c3:0608|14c3:0616|14c3:7925|17cb:1107"; then
         if ! sed -n '/\[cm4\]/,/\[*\]/p' $CONFIG_FILE | grep -q "^\s*dtoverlay=pcie-32bit-dma"; then
             debugger "pcie-32bit-dma overlay not enabled in cm4 config section, enabling it now"
             if sed -n '/\[cm4\]/,/\[*\]/p' $CONFIG_FILE | grep -q "^\s*#dtoverlay=pcie-32bit-dma"; then


### PR DESCRIPTION
## Summary

Adding support for QCA ath12k WCN785x
## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: 

## Proposed change

Enables pcie-32bit-dma when device id `17cb:1107` is present.

## Testing

<!-- How was this tested? -->
- [ ] Added/updated automated tests
- [X] Tested manually on a WLAN Pi
- [ ] Tested in another environment

## AI assistance

- [X] I used AI/LLM assistance
- If yes: Tool(s) used: Gemini for ath12k debugging.

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/WLAN-Pi/.github/blob/main/docs/contributing.md)
- [X] I targeted the correct branch (in general: `dev` for features/fixes, `main` for hotfixes)
- [X] This PR fixes/closes issue #_ (or relates to issue #37 
closes #68 

## Breaking changes

- **What breaks:** 
- **Migration needed:** 
