### PR TITLE
Don't post to Slack from fork PRs

### DIFF
--- a/.github/workflows/build-and-archive-debian-package.yml
+++ b/.github/workflows/build-and-archive-debian-package.yml
@@ -37,7 +37,7 @@ jobs:
           path: ${{ steps.build-debian-package.outputs.deb-package }}
 
   slack-workflow-status:
-    if: always()
+    if: ${{ always() && github.repository_owner == 'WLAN-Pi' && ! github.event.pull_request.head.repo.fork }}
     name: Post Workflow Status to Slack
     needs:
       - sbuild

--- a/.github/workflows/deploy-to-packagecloud.yml
+++ b/.github/workflows/deploy-to-packagecloud.yml
@@ -64,7 +64,7 @@ jobs:
           echo "${out}" | grep -q "success!"
 
   slack-workflow-status:
-    if: always()
+    if: ${{ always() && github.repository_owner == 'WLAN-Pi' && ! github.event.pull_request.head.repo.fork }}
     name: Post Workflow Status to Slack
     needs:
       - sbuild


### PR DESCRIPTION
Closes #75

The `slack-workflow-status` step ran with `if: always()`, so it fired on fork-based PRs where `SLACK_WEBHOOK_URL` is not available, failing with:

```
Error: Either slack_bot_token or slack_webhook_url is required.
```

The concern is **forks**, not PRs in general: same-repo (org branch) PRs do have secrets and should still notify. Guard the step so it skips only fork PRs:

```yaml
if: ${{ always() && github.repository_owner == 'WLAN-Pi' && ! github.event.pull_request.head.repo.fork }}
```

`github.event.pull_request.head.repo.fork` is null for push events (step runs), `false` for same-repo PRs (step runs, secrets present), and `true` for fork PRs (step skipped). This matches the pattern already used in other WLAN-Pi repos. Applied to both workflows for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)