### PR TITLE
Bump to 1.1.46 to build and deploy the DNS and Slack fixes

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+wlanpi-common (1.1.46) unstable; urgency=medium
+
+  * publicip: fast DNS pre-check with distinct "DNS unreachable" / "DNS failed"
+    states so the FPMS screen shows the cause and fails in ~2s instead of ~20s
+  * CI: do not post to Slack from fork PRs (secrets are unavailable there)
+
+ -- Josh Schmelzle <josh@joshschmelzle.com>  Mon, 13 Jul 2026 15:49:39 -0400
+
 wlanpi-common (1.1.45) unstable; urgency=medium
 
   * Rebuild to publish packages for Debian trixie to packagecloud


### PR DESCRIPTION
Version bump to trigger a packagecloud build and deploy of the changes already merged to main since 1.1.45:

- **publicip DNS fix** (#81): fast pre-check with distinct `DNS unreachable` / `DNS failed` states; ~2s instead of ~20s on a broken resolver. Hardware-verified on a WLAN Pi (trixie/aarch64).
- **Slack CI fix** (#80): don't post to Slack from fork PRs where secrets are unavailable.

Merging this triggers `deploy-to-packagecloud` (changelog path filter) to build and publish `wlanpi-common 1.1.46` to `debian/trixie`.

After merge, confirm 1.1.46 appears in https://packagecloud.io/wlanpi/dev/debian/dists/trixie/main/binary-arm64/Packages. The deploy now verifies the push, so a green run means it actually landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)